### PR TITLE
Onboarding the days with wet-bulb temperature above threshold in °C

### DIFF
--- a/src/hazard/models/water_temp.md
+++ b/src/hazard/models/water_temp.md
@@ -4,6 +4,7 @@ $$I =  \frac{52}{n_y} \sum_{i = 1}^{n_y} \boldsymbol{\mathbb{1}}_{T^{avg}_i > T^
 
 $I$ is the indicator, $T^\text{avg}_i$ is the weekly average water temperature for week index $i$ in °C, $n_y$ is the number of weeks in the sample
 and $T^\text{ref}$ is the reference temperature.
+
 The OS-Climate-generated indicators are inferred from downscaled CMIP5 data. This is done for 5 Global Circulation Models: GFDL-ESM2M, HadGEM2-ES, ISPL-CM5A-LR, MIROC-ESM-CHEM and NorESM1-M.
 The downscaled data is sourced from the [Futurestreams dataset](https://geo.public.data.uu.nl/vault-futurestreams/research-futurestreams%5B1633685642%5D/original/waterTemp/) on the data publication platform of Utrecht University.
 Indicators are generated for periods: 'historical' (averaged over 1976-2005), 2020 (2006-2030), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and 2090 (2081-2100).

--- a/src/hazard/models/wet_bulb_globe_temp.md
+++ b/src/hazard/models/wet_bulb_globe_temp.md
@@ -2,16 +2,16 @@ Days per year for which the 'Wet Bulb Globe Temperature' indicator is above a th
 
 $$I =  \frac{365}{n_y} \sum_{i = 1}^{n_y} \boldsymbol{\mathbb{1}}_{T^\text{WBGT}_i > T^\text{ref}}$$
 
-$n_y$ is the number of weeks in the sample. The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
+$n_y$ is the number of days in the sample. The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
 
 $$
 T^\text{WBGT}_i = 0.567 \times T^\text{avg}_i + 0.393 \times p^\text{vapour}_i + 3.94
 $$
 
-The water vapour partial pressure $p^\text{vapour}$ is calculated from relative humidity $h_r$:
+The water vapour partial pressure $p^\text{vapour}$ is calculated from relative humidity $h^\text{relative}$:
 
 $$
-p^\text{vapour}_i = \frac{h_r}{100} \times 6.105 \times \exp \left( \frac{17.27 \times T^\text{avg}_i}{237.7 + T^\text{avg}_i} \right)
+p^\text{vapour}_i = \frac{h^\text{relative}_i}{100} \times 6.105 \times \exp \left( \frac{17.27 \times T^\text{avg}_i}{237.7 + T^\text{avg}_i} \right)
 $$
 
 The OS-Climate-generated indicators are inferred from downscaled CMIP6 data, averaged over for 6 Global Circulation Models: ACCESS-CM2, CMCC-ESM2, CNRM-CM6-1, MPI-ESM1-2-LR, MIROC6 and NorESM2-MM.

--- a/src/hazard/models/wet_bulb_globe_temp.md
+++ b/src/hazard/models/wet_bulb_globe_temp.md
@@ -2,7 +2,7 @@ Days per year for which the 'Wet Bulb Globe Temperature' indicator is above a th
 
 $$I =  \frac{365}{n_y} \sum_{i = 1}^{n_y} \boldsymbol{\mathbb{1}}_{T^\text{WBGT}_i > T^\text{ref}}$$
 
-$n_y$ is the number of days in the sample and $T^\text{ref}$ is the reference temperature. 
+$I$ is the indicator, $n_y$ is the number of days in the sample and $T^\text{ref}$ is the reference temperature. 
 
 The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
 

--- a/src/hazard/models/wet_bulb_globe_temp.md
+++ b/src/hazard/models/wet_bulb_globe_temp.md
@@ -2,7 +2,7 @@ Days per year for which the 'Wet Bulb Globe Temperature' indicator is above a th
 
 $$I =  \frac{365}{n_y} \sum_{i = 1}^{n_y} \boldsymbol{\mathbb{1}}_{T^\text{WBGT}_i > T^\text{ref}}$$
 
-The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
+$n_y$ is the number of weeks in the sample. The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
 
 $$
 T^\text{WBGT}_i = 0.567 \times T^\text{avg}_i + 0.393 \times p^\text{vapour}_i + 3.94
@@ -14,9 +14,6 @@ $$
 p^\text{vapour}_i = \frac{h_r}{100} \times 6.105 \times \exp \left( \frac{17.27 \times T^\text{avg}_i}{237.7 + T^\text{avg}_i} \right)
 $$
 
-The OS-Climate-generated indicators are inferred from CMIP6 data, averaged over 6 models: ACCESS-CM2, CMCC-ESM2, CNRM-CM6-1, MPI-ESM1-2-LR, MIROC6 and NorESM2-MM.
-The indicators are generated for periods: 'historical' (averaged over 1995-2014), 2030 (2021-2040), 2040 (2031-2050) and 2050 (2041-2060).
-
 The OS-Climate-generated indicators are inferred from downscaled CMIP6 data, averaged over for 6 Global Circulation Models: ACCESS-CM2, CMCC-ESM2, CNRM-CM6-1, MPI-ESM1-2-LR, MIROC6 and NorESM2-MM.
 The downscaled data is sourced from the [NASA Earth Exchange Global Daily Downscaled Projections](https://www.nccs.nasa.gov/services/data-collections/land-based-products/nex-gddp-cmip6).
-Indicators are generated for periods: 'historical' (averaged over 1995-2014), 2030 (2021-2040), 2040 (2031-2050) and 2050 (2041-2060).
+Indicators are generated for periods: 'historical' (averaged over 1995-2014), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and  2090 (2081-2100).

--- a/src/hazard/models/wet_bulb_globe_temp.md
+++ b/src/hazard/models/wet_bulb_globe_temp.md
@@ -1,0 +1,22 @@
+Days per year for which the 'Wet Bulb Globe Temperature' indicator is above a threshold specified in °C:
+
+$$I =  \frac{365}{n_y} \sum_{i = 1}^{n_y} \boldsymbol{\mathbb{1}}_{T^\text{WBGT}_i > T^\text{ref}}$$
+
+The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
+
+$$
+T^\text{WBGT}_i = 0.567 \times T^\text{avg}_i + 0.393 \times p^\text{vapour}_i + 3.94
+$$
+
+The water vapour partial pressure $p^\text{vapour}$ is calculated from relative humidity $h_r$:
+
+$$
+p^\text{vapour}_i = \frac{h_r}{100} \times 6.105 \times \exp \left( \frac{17.27 \times T^\text{avg}_i}{237.7 + T^\text{avg}_i} \right)
+$$
+
+The OS-Climate-generated indicators are inferred from CMIP6 data, averaged over 6 models: ACCESS-CM2, CMCC-ESM2, CNRM-CM6-1, MPI-ESM1-2-LR, MIROC6 and NorESM2-MM.
+The indicators are generated for periods: 'historical' (averaged over 1995-2014), 2030 (2021-2040), 2040 (2031-2050) and 2050 (2041-2060).
+
+The OS-Climate-generated indicators are inferred from downscaled CMIP6 data, averaged over for 6 Global Circulation Models: ACCESS-CM2, CMCC-ESM2, CNRM-CM6-1, MPI-ESM1-2-LR, MIROC6 and NorESM2-MM.
+The downscaled data is sourced from the [NASA Earth Exchange Global Daily Downscaled Projections](https://www.nccs.nasa.gov/services/data-collections/land-based-products/nex-gddp-cmip6).
+Indicators are generated for periods: 'historical' (averaged over 1995-2014), 2030 (2021-2040), 2040 (2031-2050) and 2050 (2041-2060).

--- a/src/hazard/models/wet_bulb_globe_temp.md
+++ b/src/hazard/models/wet_bulb_globe_temp.md
@@ -2,7 +2,9 @@ Days per year for which the 'Wet Bulb Globe Temperature' indicator is above a th
 
 $$I =  \frac{365}{n_y} \sum_{i = 1}^{n_y} \boldsymbol{\mathbb{1}}_{T^\text{WBGT}_i > T^\text{ref}}$$
 
-$n_y$ is the number of days in the sample. The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
+$n_y$ is the number of days in the sample and $T^\text{ref}$ is the reference temperature. 
+
+The 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in °C denoted $T^\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\text{vapour}$:
 
 $$
 T^\text{WBGT}_i = 0.567 \times T^\text{avg}_i + 0.393 \times p^\text{vapour}_i + 3.94

--- a/src/hazard/models/wet_bulb_globe_temp.py
+++ b/src/hazard/models/wet_bulb_globe_temp.py
@@ -1,0 +1,154 @@
+import logging
+import os
+from contextlib import ExitStack
+from pathlib import PurePosixPath
+from typing import Iterable, List
+
+import numpy as np
+import xarray as xr
+
+from hazard.inventory import Colormap, HazardResource, MapInfo, Scenario
+from hazard.models.multi_year_average import (BatchItem, Indicator,
+                                              ThresholdBasedAverageIndicator)
+from hazard.protocols import OpenDataset
+
+logger = logging.getLogger(__name__)
+
+
+class WetBulbGlobeTemperatureAboveIndicator(ThresholdBasedAverageIndicator):
+    def __init__(
+        self,
+        threshold_temps_c: List[float] = [
+            5,
+            10,
+            15,
+            20,
+            25,
+            30,
+            35,
+            40,
+            45,
+            50,
+            55,
+            60,
+        ],
+        window_years: int = 20,
+        gcms: Iterable[str] = [
+            "ACCESS-CM2",
+            "CMCC-ESM2",
+            "CNRM-CM6-1",
+            "MPI-ESM1-2-LR",
+            "MIROC6",
+            "NorESM2-MM",
+        ],
+        scenarios: Iterable[str] = [
+            "historical",
+            "ssp126",
+            "ssp245",
+            "ssp370",
+            "ssp585",
+        ],
+        central_year_historical: int = 2005,
+        central_years: Iterable[int] = [2030, 2040, 2050, 2060, 2070, 2080, 2090],
+    ):
+        super().__init__(
+            window_years=window_years,
+            gcms=gcms,
+            scenarios=scenarios,
+            central_year_historical=central_year_historical,
+            central_years=central_years,
+        )
+        self.threshold_temps_c = threshold_temps_c
+
+    def _calculate_single_year_indicators(
+        self, source: OpenDataset, item: BatchItem, year: int
+    ) -> List[Indicator]:
+        logger.info(f"Starting calculation for year {year}")
+        with ExitStack() as stack:
+            tas = stack.enter_context(
+                source.open_dataset_year(item.gcm, item.scenario, "tas", year)
+            ).tas
+            hurs = stack.enter_context(
+                source.open_dataset_year(item.gcm, item.scenario, "hurs", year)
+            ).hurs
+            results = self._days_wbgt_above_indicators(tas, hurs)
+        resource = item.resource
+        path = item.resource.path.format(
+            gcm=item.gcm, scenario=item.scenario, year=item.central_year
+        )
+        assert isinstance(resource.map, MapInfo)
+        result = [
+            Indicator(
+                results,
+                PurePosixPath(path),
+                item.resource.map.bounds,
+            )
+        ]
+        logger.info(f"Calculation complete for year {year}")
+        return result
+
+    def _days_wbgt_above_indicators(
+        self, tas: xr.DataArray, hurs: xr.DataArray
+    ) -> List[xr.DataArray]:
+        """Create DataArrays containing indicators the thresholds for a single year."""
+        tas_c = tas - 273.15  # convert from K to C
+        # vpp is water vapour partial pressure in kPa
+        vpp = (hurs / 100.0) * 6.105 * np.exp((17.27 * tas_c) / (237.7 + tas_c))
+        wbgt = 0.567 * tas_c + 0.393 * vpp + 3.94
+        scale = 365.0 / len(wbgt.time)
+        if any(coord not in wbgt.coords.keys() for coord in ["lat", "lon", "time"]):
+            raise ValueError("expect coordinates: 'lat', 'lon' and 'time'")
+        coords = {
+            "index": self.threshold_temps_c,
+            "lat": wbgt.coords["lat"].values,
+            "lon": wbgt.coords["lon"].values,
+        }
+        output = xr.DataArray(coords=coords, dims=coords.keys())
+        for i, threshold_c in enumerate(self.threshold_temps_c):
+            output[i, :, :] = xr.where(wbgt > threshold_c, scale, 0.0).sum(dim=["time"])
+        return output
+
+    def _resource(self) -> HazardResource:
+        """Create resource."""
+        with open(
+            os.path.join(os.path.dirname(__file__), "wet_bulb_globe_temp.md"), "r"
+        ) as f:
+            description = f.read()
+        resource = HazardResource(
+            hazard_type="ChronicHeat",
+            indicator_id="days_wbgt_above",
+            indicator_model_id=None,
+            indicator_model_gcm="{gcm}",
+            params={"gcm": self.gcms},
+            path="chronic_heat/osc/v2/days_wbgt_above_{gcm}_{scenario}_{year}",
+            display_name="Days with wet-bulb globe temperature above threshold in degrees celsius/{gcm}",
+            description=description,
+            display_groups=[
+                "Days with wet-bulb globe temperature above threshold in degrees celsius"
+            ],  # display names of groupings
+            group_id="",
+            map=MapInfo(
+                colormap=Colormap(
+                    name="heating",
+                    nodata_index=0,
+                    min_index=1,
+                    min_value=0.0,
+                    max_value=100,
+                    max_index=255,
+                    units="days/year",
+                ),
+                bounds=[(-180.0, 85.0), (180.0, 85.0), (180.0, -85.0), (-180.0, -85.0)],
+                path="maps/chronic_heat/osc/v2/days_wbgt_above_{gcm}_{scenario}_{year}_map",
+                index_values=self.threshold_temps_c,
+                source="map_array",
+            ),
+            units="days/year",
+            scenarios=[
+                Scenario(id="historical", years=[self.central_year_historical]),
+                Scenario(id="ssp126", years=list(self.central_years)),
+                Scenario(id="ssp245", years=list(self.central_years)),
+                Scenario(id="ssp370", years=list(self.central_years)),
+                Scenario(id="ssp585", years=list(self.central_years)),
+            ],
+        )
+        return resource

--- a/src/inventories/hazard/inventory.json
+++ b/src/inventories/hazard/inventory.json
@@ -1914,7 +1914,7 @@
             "display_groups": [
                 "Weeks with average temperature above threshold in degrees celsius"
             ],
-            "description": "Weeks per year for which the average water temperature is above a threshold specified in \u00c2\u00b0C:\n\n$$I =  \\frac{52}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{T^{avg}_i > T^\\text{ref}}$$\n\n$I$ is the indicator, $T^\\text{avg}_i$ is the weekly average water temperature for week index $i$ in \u00c2\u00b0C, $n_y$ is the number of weeks in the sample\nand $T^\\text{ref}$ is the reference temperature.\nThe OS-Climate-generated indicators are inferred from downscaled CMIP5 data. This is done for 5 Global Circulation Models: GFDL-ESM2M, HadGEM2-ES, ISPL-CM5A-LR, MIROC-ESM-CHEM and NorESM1-M.\nThe downscaled data is sourced from the [Futurestreams dataset](https://geo.public.data.uu.nl/vault-futurestreams/research-futurestreams%5B1633685642%5D/original/waterTemp/) on the data publication platform of Utrecht University.\nIndicators are generated for periods: 'historical' (averaged over 1976-2005), 2020 (2006-2030), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and 2090 (2081-2100).\n",
+            "description": "Weeks per year for which the average water temperature is above a threshold specified in \u00c2\u00b0C:\n\n$$I =  \\frac{52}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{T^{avg}_i > T^\\text{ref}}$$\n\n$I$ is the indicator, $T^\\text{avg}_i$ is the weekly average water temperature for week index $i$ in \u00c2\u00b0C, $n_y$ is the number of weeks in the sample\nand $T^\\text{ref}$ is the reference temperature.\n\nThe OS-Climate-generated indicators are inferred from downscaled CMIP5 data. This is done for 5 Global Circulation Models: GFDL-ESM2M, HadGEM2-ES, ISPL-CM5A-LR, MIROC-ESM-CHEM and NorESM1-M.\nThe downscaled data is sourced from the [Futurestreams dataset](https://geo.public.data.uu.nl/vault-futurestreams/research-futurestreams%5B1633685642%5D/original/waterTemp/) on the data publication platform of Utrecht University.\nIndicators are generated for periods: 'historical' (averaged over 1976-2005), 2020 (2006-2030), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and 2090 (2081-2100).\n",
             "map": {
                 "colormap": {
                     "min_index": 1,
@@ -2037,7 +2037,7 @@
             "display_groups": [
                 "Weeks with average temperature above threshold in degrees celsius"
             ],
-            "description": "Weeks per year for which the average water temperature is above a threshold specified in \u00c2\u00b0C:\n\n$$I =  \\frac{52}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{T^{avg}_i > T^\\text{ref}}$$\n\n$I$ is the indicator, $T^\\text{avg}_i$ is the weekly average water temperature for week index $i$ in \u00c2\u00b0C, $n_y$ is the number of weeks in the sample\nand $T^\\text{ref}$ is the reference temperature.\nThe OS-Climate-generated indicators are inferred from downscaled CMIP5 data. This is done for 5 Global Circulation Models: GFDL-ESM2M, HadGEM2-ES, ISPL-CM5A-LR, MIROC-ESM-CHEM and NorESM1-M.\nThe downscaled data is sourced from the [Futurestreams dataset](https://geo.public.data.uu.nl/vault-futurestreams/research-futurestreams%5B1633685642%5D/original/waterTemp/) on the data publication platform of Utrecht University.\nIndicators are generated for periods: 'historical' (averaged over 1979-2005), 2020 (2006-2030), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and 2090 (2081-2100).\n",
+            "description": "Weeks per year for which the average water temperature is above a threshold specified in \u00c2\u00b0C:\n\n$$I =  \\frac{52}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{T^{avg}_i > T^\\text{ref}}$$\n\n$I$ is the indicator, $T^\\text{avg}_i$ is the weekly average water temperature for week index $i$ in \u00c2\u00b0C, $n_y$ is the number of weeks in the sample\nand $T^\\text{ref}$ is the reference temperature.\n\nThe OS-Climate-generated indicators are inferred from downscaled CMIP5 data. This is done for 5 Global Circulation Models: GFDL-ESM2M, HadGEM2-ES, ISPL-CM5A-LR, MIROC-ESM-CHEM and NorESM1-M.\nThe downscaled data is sourced from the [Futurestreams dataset](https://geo.public.data.uu.nl/vault-futurestreams/research-futurestreams%5B1633685642%5D/original/waterTemp/) on the data publication platform of Utrecht University.\nIndicators are generated for periods: 'historical' (averaged over 1979-2005), 2020 (2006-2030), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and 2090 (2081-2100).\n",
             "map": {
                 "colormap": {
                     "min_index": 1,
@@ -2095,6 +2095,131 @@
                 }
             ],
             "units": "weeks/year"
+        },
+        {
+            "hazard_type": "ChronicHeat",
+            "group_id": "",
+            "path": "chronic_heat/osc/v2/days_wbgt_above_{gcm}_{scenario}_{year}",
+            "indicator_id": "days_wbgt_above",
+            "indicator_model_id": null,
+            "indicator_model_gcm": "{gcm}",
+            "params": {
+                "gcm": [
+                    "ACCESS-CM2",
+                    "CMCC-ESM2",
+                    "CNRM-CM6-1",
+                    "MPI-ESM1-2-LR",
+                    "MIROC6",
+                    "NorESM2-MM"
+                ]
+            },
+            "display_name": "Days with wet-bulb globe temperature above threshold in degrees celsius/{gcm}",
+            "display_groups": [
+                "Days with wet-bulb globe temperature above threshold in degrees celsius"
+            ],
+            "description": "Days per year for which the 'Wet Bulb Globe Temperature' indicator is above a threshold specified in \u00c2\u00b0C:\n\n$$I =  \\frac{365}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{T^\\text{WBGT}_i > T^\\text{ref}}$$\n\n$I$ is the indicator, $n_y$ is the number of days in the sample and $T^\\text{ref}$ is the reference temperature. \n\nThe 'Wet-Bulb Globe Temperature' (WBGT) indicator is calculated from both the average daily near-surface surface temperature in \u00c2\u00b0C denoted $T^\\text{avg}$ and the water vapour partial pressure in kPa denoted $p^\\text{vapour}$:\n\n$$\nT^\\text{WBGT}_i = 0.567 \\times T^\\text{avg}_i + 0.393 \\times p^\\text{vapour}_i + 3.94\n$$\n\nThe water vapour partial pressure $p^\\text{vapour}$ is calculated from relative humidity $h^\\text{relative}$:\n\n$$\np^\\text{vapour}_i = \\frac{h^\\text{relative}_i}{100} \\times 6.105 \\times \\exp \\left( \\frac{17.27 \\times T^\\text{avg}_i}{237.7 + T^\\text{avg}_i} \\right)\n$$\n\nThe OS-Climate-generated indicators are inferred from downscaled CMIP6 data, averaged over for 6 Global Circulation Models: ACCESS-CM2, CMCC-ESM2, CNRM-CM6-1, MPI-ESM1-2-LR, MIROC6 and NorESM2-MM.\nThe downscaled data is sourced from the [NASA Earth Exchange Global Daily Downscaled Projections](https://www.nccs.nasa.gov/services/data-collections/land-based-products/nex-gddp-cmip6).\nIndicators are generated for periods: 'historical' (averaged over 1995-2014), 2030 (2021-2040), 2040 (2031-2050), 2050 (2041-2060), 2060 (2051-2070), 2070 (2061-2080), 2080 (2071-2090) and  2090 (2081-2100).\n",
+            "map": {
+                "colormap": {
+                    "min_index": 1,
+                    "min_value": 0.0,
+                    "max_index": 255,
+                    "max_value": 100.0,
+                    "name": "heating",
+                    "nodata_index": 0,
+                    "units": "days/year"
+                },
+                "path": "maps/chronic_heat/osc/v2/days_wbgt_above_{gcm}_{scenario}_{year}_map",
+                "bounds": [
+                    [
+                        -180.0,
+                        85.0
+                    ],
+                    [
+                        180.0,
+                        85.0
+                    ],
+                    [
+                        180.0,
+                        -85.0
+                    ],
+                    [
+                        -180.0,
+                        -85.0
+                    ]
+                ],
+                "index_values": [
+                    5,
+                    10,
+                    15,
+                    20,
+                    25,
+                    30,
+                    35,
+                    40,
+                    45,
+                    50,
+                    55,
+                    60
+                ],
+                "source": "map_array"
+            },
+            "scenarios": [
+                {
+                    "id": "historical",
+                    "years": [
+                        2005
+                    ]
+                },
+                {
+                    "id": "ssp126",
+                    "years": [
+                        2030,
+                        2040,
+                        2050,
+                        2060,
+                        2070,
+                        2080,
+                        2090
+                    ]
+                },
+                {
+                    "id": "ssp245",
+                    "years": [
+                        2030,
+                        2040,
+                        2050,
+                        2060,
+                        2070,
+                        2080,
+                        2090
+                    ]
+                },
+                {
+                    "id": "ssp370",
+                    "years": [
+                        2030,
+                        2040,
+                        2050,
+                        2060,
+                        2070,
+                        2080,
+                        2090
+                    ]
+                },
+                {
+                    "id": "ssp585",
+                    "years": [
+                        2030,
+                        2040,
+                        2050,
+                        2060,
+                        2070,
+                        2080,
+                        2090
+                    ]
+                }
+            ],
+            "units": "days/year"
         }
     ]
 }

--- a/src/test/test_inventory.py
+++ b/src/test/test_inventory.py
@@ -7,6 +7,8 @@ from hazard.docs_store import DocStore, HazardResources
 from hazard.models.days_tas_above import DaysTasAboveIndicator
 from hazard.models.degree_days import DegreeDays, HeatingCoolingDegreeDays
 from hazard.models.water_temp import WaterTemperatureAboveIndicator
+from hazard.models.wet_bulb_globe_temp import \
+    WetBulbGlobeTemperatureAboveIndicator
 from hazard.models.work_loss import WorkLossIndicator
 from hazard.onboard.iris_wind import IRISIndicator
 from hazard.onboard.jupiter import Jupiter
@@ -39,6 +41,7 @@ def test_create_inventory(test_output_dir):
         IRISIndicator(None),
         HeatingCoolingDegreeDays(),
         WaterTemperatureAboveIndicator(),
+        WetBulbGlobeTemperatureAboveIndicator(),
     ]
 
     docs_store.write_new_empty_inventory()

--- a/src/test/test_water_temp_indicators.py
+++ b/src/test/test_water_temp_indicators.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from hazard.models.water_temp import FutureStreamsSource, WaterTemperatureAboveIndicator
+from hazard.models.water_temp import (FutureStreamsSource,
+                                      WaterTemperatureAboveIndicator)
 
 from .utilities import TestSource, TestTarget, _create_test_datasets_tas
 
@@ -54,7 +55,7 @@ def test_water_temp_above_mocked():
     )
     model.run_all(source, target)
     result = target.datasets[
-        "chronic_heat/osc/v2/weeks_water_temp_above_{gcm}_{scenario}_{year}".format(
+        "chronic_heat/nluu/v2/weeks_water_temp_above_{gcm}_{scenario}_{year}".format(
             gcm=gcm, scenario=scenario, year=year
         )
     ]


### PR DESCRIPTION
This code change add "WetBulbGlobeTemperatureAbove" to onboard the number of days with WBGT above some threshold defined uniformly from 5°C to 60°C with a 5°C step. 