### PR TITLE
Chore: Pull DevOps tooling from upstream repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
   #       args: ['--py37-plus']
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.0
+    rev: 24.3.0
     hooks:
       - id: black
       - id: black-jupyter


### PR DESCRIPTION
Automated by a GitHub workflow: bootstrap.yaml