### PR TITLE
Fix degree days model inventory

### DIFF
--- a/src/hazard/docs_store.py
+++ b/src/hazard/docs_store.py
@@ -152,7 +152,7 @@ class DocStore:
 
         # if format == stac, we do a round trip, stac -> osc -> stac.
         path = self._full_path_inventory()
-        combined = {} if remove_existing else dict((i.key(), i) for i in self.read_inventory(format=format))
+        combined = {} if remove_existing else dict((i.key(), i) for i in self.read_inventory())
         for resource in resources:
             combined[resource.key()] = resource
         models = HazardResources(resources=list(combined.values()))

--- a/src/hazard/models/degree_days.py
+++ b/src/hazard/models/degree_days.py
@@ -87,6 +87,17 @@ class DegreeDays(IndicatorModel[BatchItem]):
     def _resource(self):
         with open(os.path.join(os.path.dirname(__file__), "degree_days.md"), "r") as f:
             description = f.read().replace("\u00c2\u00b0", "\u00b0")
+
+        scenarios = []
+
+        if "historical" in self.scenarios:
+            scenarios.append(Scenario(id="historical", years=[self.central_year_historical]))
+
+        for s in self.scenarios:
+            if s == "historical":
+                continue
+            scenarios.append(Scenario(id=s, years=list(self.central_years)))
+
         resource = HazardResource(
             hazard_type="ChronicHeat",
             indicator_id=f"mean_degree_days/above/{self.threshold_c}c",
@@ -112,12 +123,7 @@ class DegreeDays(IndicatorModel[BatchItem]):
                 source="map_array",
             ),
             units="degree days",
-            scenarios=[
-                Scenario(id="historical", years=[self.central_year_historical]),
-                Scenario(id="ssp126", years=list(self.central_years)),
-                Scenario(id="ssp245", years=list(self.central_years)),
-                Scenario(id="ssp585", years=list(self.central_years)),
-            ],
+            scenarios=scenarios,
         )
         return resource
 


### PR DESCRIPTION
In the degree days model resources, the list of scenarios was hard coded to be the list of all possible scenarios, whereas the model exposes an option to only run selected scenarios. I fixed the resources by removing this hard coded and list and reuse what's passed as an option instead.

I also fixed an inventory I/O bug I introduced in a recent PR. 