### PR TITLE
feat: swap CEDA FTP usage for HTTP access

### DIFF
--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -10,13 +10,10 @@ $graph:
         ramMax: 4096
 
     inputs:
-      ceda_ftp_username:
+      ceda_username:
         type: string
         default: ""
-      ceda_ftp_password:
-        type: string
-        default: ""
-      ceda_ftp_url:
+      ceda_password:
         type: string
         default: ""
       source_dataset:
@@ -63,9 +60,8 @@ $graph:
       indicator-step:
         run: "#indicator-command"
         in:
-          ceda_ftp_username: ceda_ftp_username
-          ceda_ftp_password: ceda_ftp_password
-          ceda_ftp_url: ceda_ftp_url
+          ceda_username: ceda_username
+          ceda_password: ceda_password
           source_dataset: source_dataset
           source_dataset_kwargs: source_dataset_kwargs
           gcm_list: gcm_list
@@ -88,7 +84,7 @@ $graph:
 
     hints:
       DockerRequirement:
-        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:14edea7
+        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:48a77e6
 
     requirements:
       ResourceRequirement:
@@ -98,16 +94,13 @@ $graph:
         networkAccess: true
       EnvVarRequirement:
           envDef:
-            CEDA_FTP_USERNAME: $(inputs.ceda_ftp_username)
-            CEDA_FTP_URL: $(inputs.ceda_ftp_url)
-            CEDA_FTP_PASSWORD: $(inputs.ceda_ftp_password)
+            CEDA_USERNAME: $(inputs.ceda_username)
+            CEDA_PASSWORD: $(inputs.ceda_password)
 
     inputs:
-      ceda_ftp_username:
+      ceda_username:
         type: string
-      ceda_ftp_password:
-        type: string
-      ceda_ftp_url:
+      ceda_password:
         type: string
       source_dataset:
         type: string

--- a/src/hazard/cli.py
+++ b/src/hazard/cli.py
@@ -20,6 +20,7 @@ def days_tas_above_indicator(
     store: Optional[str] = None,
     write_xarray_compatible_zarr: Optional[bool] = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs,  # To allow for extra parameters to the CLI, due to how CWL will provide all input parameters
 ):
     hazard_services.days_tas_above_indicator(
         source_dataset,
@@ -52,6 +53,7 @@ def degree_days_indicator(
     store: Optional[str] = None,
     write_xarray_compatible_zarr: Optional[bool] = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs,  # To allow for extra parameters to the CLI, due to how CWL will provide all input parameters
 ):
     hazard_services.degree_days_indicator(
         source_dataset,


### PR DESCRIPTION
# What this PR is

Whilst I've been away, CEDA completely removed their FTP capabilities 😢 

This PR swaps in a method for listing available files via a `?json` parameter to their `data` urls and then uses the OPeNDAP CEDA service to download them

# How I did it

* Swapped to just `CEDA_USERNAME` and `CEDA_PASSWORD` throughout CWL, CLI, and UKCP18 implementation
* `src/hazard/sources/ukcp18.py` now generates an authentication token with CEDA, queries their data service, and fetches data via their OPeNDAP service
* `src/hazard/cli.py` I removed the `**kwargs` arguments previously and that was incorrect, they're needed so that Fire doesn't complain when CWL passes it parameters it isn't going to use for that specific indicator

# How you can test it

Bit difficult at the moment as a whole, because we're having issues with the new zarr format. But you can get it to a failing point (past fetching the UKCP18 data) with:

```
CEDA_USERNAME={YOUR USERNAME} CEDA_PASSWORD={YOUR_PASSWORD} os_climate_hazard degree_days_indicator --store ./uk_60km_dd_28 --source_dataset UKCP18 --source_dataset_kwargs "{'resolution':'60km','domain':'uk'}" --gcm_list "[ukcp18]" --scenario_list "[rcp85]" --threshold_list "[]" --threshold_temperature 28 --central_year_list "[2030,2040,2050,2060,2070,2080,2090]" --central_year_historical 2005 --window_years 20 --write_xarray_compatible_zarr true --dask_cluster_kwargs "{'n_workers': 1, 'threads_per_worker': 1}"

```
