### PR TITLE
Fix: Address linting issue with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,6 @@ Downloads = "https://github.com/os-climate/hazard/releases"
 Documentation = "https://github.com/os-climate/hazard/tree/main/docs"
 "Source Code" = "https://github.com/os-climate/hazard"
 
-[metadata]
-license-files = ["LICENSE"]
-
 [build-system]
 requires = [
     "setuptools>=42",


### PR DESCRIPTION
Fixes:

Invalid file: pyproject.toml
[ERROR] `data` must not contain {'meta`data`'} properties