### PR TITLE
fix: package sources markdown files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ include = ["hazard*"]
 [tool.setuptools.package-data]
 hazard = [
   "models/*.md",
-  "onboard/*.md"
+  "onboard/*.md",
+  "sources/*.md"
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
We added markdown descriptions for a few sources a while back and because we've just been running hazard from its own repo, we've not had issues. But I just installed hazard in a new project and got bit by me not adding them into the package data 🙈 

Fixing that.